### PR TITLE
[CC-282] Handle JS redirects manually

### DIFF
--- a/stylify-crawler.js
+++ b/stylify-crawler.js
@@ -255,7 +255,6 @@ function crawl() {
 			if (main && url != address) {
 				address = url;
 				page.close();
-				// // crawl();
 				setTimeout(crawl, 100); //Note the setTimeout here
 			}
 		};

--- a/stylify-crawler.js
+++ b/stylify-crawler.js
@@ -254,8 +254,8 @@ function crawl() {
 		page.onNavigationRequested = function (url, type, willNavigate, main) {
 			url = url.replace(/#.+/, "")
 
-			if (main && newAddress != address) {
-				address = newAddress;
+			if (main && url != address) {
+				address = url;
 				page.close();
 				setTimeout(crawl, 100); //Note the setTimeout here
 			}

--- a/stylify-crawler.js
+++ b/stylify-crawler.js
@@ -252,8 +252,10 @@ function crawl() {
 		};
 
 		page.onNavigationRequested = function (url, type, willNavigate, main) {
-			if (main && url != address) {
-				address = url;
+			url = url.replace(/#.+/, "")
+
+			if (main && newAddress != address) {
+				address = newAddress;
 				page.close();
 				setTimeout(crawl, 100); //Note the setTimeout here
 			}

--- a/stylify-crawler.js
+++ b/stylify-crawler.js
@@ -1,52 +1,9 @@
 "use strict";
-var	page = require('webpage').create(),
-	args = require('system').args,
-	address, isDebug, saveImage;
+var	args = require('system').args,
+	page, address, isDebug, saveImage;
 
 /*phantom settings*/
 phantom.cookiesEnabled = true;
-/*request and render settings*/
-page.zoomFactor = 1;
-page.viewportSize = { width: 1024, height: 768 };
-var config = {
-	tempImgPath : "public/temp-img/",
-	jQueryPath : "lib/jquery-2.1.1.min.js",
-	//pretend to be Safari 9 - (similar engine as PhantomJS) change this if you want to pretend to be another browser
-	userAgent : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/601.1.56 (KHTML, like Gecko) Version/9.0 Safari/537.86.1"
-};
-
-page.settings.userAgent = config.userAgent;
-
-//print out console logs on page level
-page.onConsoleMessage = function (msg) {
-	if (msg.indexOf("Unsafe JavaScript attempt to access frame with URL") > -1){
-		return;
-	}
-	if(isDebug){
-		console.log('CONSOLE: ' + msg);
-	}
-};
-
-page.onAlert = function (msg) {
-	//ignore alerts
-	//console.log('ALERT: ' + msg);
-};
-
-//error tracing
-page.onError = function(msg, trace) {
-    var msgStack = ['ERROR: ' + msg];
-    if (trace) {
-        msgStack.push('TRACE:');
-        trace.forEach(function(t) {
-            msgStack.push(' -> ' + (t.file||t.sourceURL) + ': ' + t.line + (t.function ? ' (in function ' + t.function + ')' : ''));
-        });
-    }
-    if(isDebug){
-    	console.error(msgStack.join('\n'));
-	}
-	//phantom.exit();
-	return;
-};
 
 phantom.onError = function(msg, trace) {
     var msgStack = ['PHANTOM ERROR: ' + msg];
@@ -71,6 +28,14 @@ var utils = {
 			return true;
 		}else{
 			return false;
+		}
+	},
+	log : function(msg) {
+		if (msg.indexOf("Unsafe JavaScript attempt to access frame with URL") > -1){
+			return;
+		}
+		if(isDebug){
+			console.log('CONSOLE: ' + msg);
 		}
 	}
 };
@@ -242,51 +207,105 @@ function parsePage (page, address){
 	});
 };
 
-
-try{
-	//main
-	if (args.length === 0) {
-	    console.log('Usage: color-crawler.js <some URL>');
-	    phantom.exit();
-	}else{
-		address = args[1];
-		saveImage = args[2] !== "false";
-		isDebug = args[3] === "true";
-		if(utils.isValidURL(address)){
-			page.open(address, function (status) {
-			    if (status == 'success'){
-		        	//delay analizing a bit
-		        	window.setTimeout(function () {
-			        	if(page.injectJs(config.jQueryPath)){
-				    		var result = parsePage(page, address)
-				    			,imgPath = config.tempImgPath + utils.makeFilename(address) + "_" + new Date().getTime().toString() + Math.floor(Math.random()*10000) + '.png';
-				    		if(!result){
-				    			console.log("ERROR(502)"); //could not parse site
-								phantom.exit();
-				    		}
-				    		if(saveImage){
-								result.thumbPath =  imgPath.replace("public/", "");
-								page.render(imgPath);
-							}
-							//return result and save screen
-							console.log(JSON.stringify(result));
-				    		phantom.exit();
-						}else{
-							console.log("ERROR: COULD NOT LOAD JQUERY");
-							phantom.exit();
-						}
-					}, 200);
-				}else{
-		            console.log('ERROR(404)'); //Fail to load the current url
-		            phantom.exit();
+function crawl() {
+	try{
+		page = require('webpage').create()
+	
+		/*request and render settings*/
+		page.zoomFactor = 1;
+		page.viewportSize = { width: 1024, height: 768 };
+		var config = {
+			tempImgPath : "public/temp-img/",
+			jQueryPath : "lib/jquery-2.1.1.min.js",
+			//pretend to be Safari 9 - (similar engine as PhantomJS) change this if you want to pretend to be another browser
+			userAgent : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/601.1.56 (KHTML, like Gecko) Version/9.0 Safari/537.86.1"
+		};
+	
+		page.settings.userAgent = config.userAgent;
+	
+		//print out console logs on page level
+		page.onConsoleMessage = function (msg) {
+			utils.log(msg)
+		};
+	
+		page.onAlert = function (msg) {
+			//ignore alerts
+			//console.log('ALERT: ' + msg);
+		};
+	
+		//error tracing
+		page.onError = function(msg, trace) {
+				var msgStack = ['ERROR: ' + msg];
+				if (trace) {
+						msgStack.push('TRACE:');
+						trace.forEach(function(t) {
+								msgStack.push(' -> ' + (t.file||t.sourceURL) + ': ' + t.line + (t.function ? ' (in function ' + t.function + ')' : ''));
+						});
 				}
-			});
-		} else {
-			console.error("ERROR(400)"); //invalid url
-			phantom.exit();
+				if(isDebug){
+					console.error(msgStack.join('\n'));
+			}
+			//phantom.exit();
+			return;
+		};
+	
+		page.onNavigationRequested = function (url, type, willNavigate, main) {
+			console.log("nav", main, url, args[1]);
+	
+			if (main && url != args[1]) {
+				args[1] = url;
+				page.close();
+				// // crawl();
+				setTimeout(crawl, 100); //Note the setTimeout here
+			}
+		};
+	
+		//main
+		if (args.length === 0) {
+				console.log('Usage: color-crawler.js <some URL>');
+				phantom.exit();
+		}else{
+			address = args[1];
+			saveImage = args[2] !== "false";
+			isDebug = args[3] === "true";
+			if(utils.isValidURL(address)){
+				page.open(address, function (status) {
+						if (status == 'success'){
+								//delay analizing a bit
+								window.setTimeout(function () {
+									if(page.injectJs(config.jQueryPath)){
+									var result = parsePage(page, address)
+										,imgPath = config.tempImgPath + utils.makeFilename(address) + "_" + new Date().getTime().toString() + Math.floor(Math.random()*10000) + '.png';
+									if(!result){
+										console.log("ERROR(502)"); //could not parse site
+									phantom.exit();
+									}
+									if(saveImage){
+									result.thumbPath =  imgPath.replace("public/", "");
+									page.render(imgPath);
+								}
+								//return result and save screen
+								console.log(JSON.stringify(result));
+									phantom.exit();
+							}else{
+								console.log("ERROR: COULD NOT LOAD JQUERY");
+								phantom.exit();
+							}
+						}, 200);
+					}else{
+									console.log('ERROR(404)'); //Fail to load the current url
+									phantom.exit();
+					}
+				});
+			} else {
+				console.error("ERROR(400)"); //invalid url
+				phantom.exit();
+			}
 		}
+	}catch(e){
+		console.error("ERROR: " + e);
+		phantom.exit();
 	}
-}catch(e){
-	console.error("ERROR: " + e);
-	phantom.exit();
 }
+
+crawl()

--- a/stylify-crawler.js
+++ b/stylify-crawler.js
@@ -210,7 +210,7 @@ function parsePage (page, address){
 function crawl() {
 	try{
 		page = require('webpage').create()
-	
+
 		/*request and render settings*/
 		page.zoomFactor = 1;
 		page.viewportSize = { width: 1024, height: 768 };
@@ -220,19 +220,19 @@ function crawl() {
 			//pretend to be Safari 9 - (similar engine as PhantomJS) change this if you want to pretend to be another browser
 			userAgent : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/601.1.56 (KHTML, like Gecko) Version/9.0 Safari/537.86.1"
 		};
-	
+
 		page.settings.userAgent = config.userAgent;
-	
+
 		//print out console logs on page level
 		page.onConsoleMessage = function (msg) {
 			utils.log(msg)
 		};
-	
+
 		page.onAlert = function (msg) {
 			//ignore alerts
 			//console.log('ALERT: ' + msg);
 		};
-	
+
 		//error tracing
 		page.onError = function(msg, trace) {
 				var msgStack = ['ERROR: ' + msg];
@@ -248,10 +248,10 @@ function crawl() {
 			//phantom.exit();
 			return;
 		};
-	
+
 		page.onNavigationRequested = function (url, type, willNavigate, main) {
 			console.log("nav", main, url, args[1]);
-	
+
 			if (main && url != args[1]) {
 				args[1] = url;
 				page.close();
@@ -259,7 +259,7 @@ function crawl() {
 				setTimeout(crawl, 100); //Note the setTimeout here
 			}
 		};
-	
+
 		//main
 		if (args.length === 0) {
 				console.log('Usage: color-crawler.js <some URL>');

--- a/stylify-crawler.js
+++ b/stylify-crawler.js
@@ -1,6 +1,8 @@
 "use strict";
 var	args = require('system').args,
-	page, address, isDebug, saveImage;
+	page, isDebug, saveImage;
+
+var address = args[1];
 
 /*phantom settings*/
 phantom.cookiesEnabled = true;
@@ -250,10 +252,8 @@ function crawl() {
 		};
 
 		page.onNavigationRequested = function (url, type, willNavigate, main) {
-			console.log("nav", main, url, args[1]);
-
-			if (main && url != args[1]) {
-				args[1] = url;
+			if (main && url != address) {
+				address = url;
 				page.close();
 				// // crawl();
 				setTimeout(crawl, 100); //Note the setTimeout here
@@ -265,7 +265,6 @@ function crawl() {
 				console.log('Usage: color-crawler.js <some URL>');
 				phantom.exit();
 		}else{
-			address = args[1];
 			saveImage = args[2] !== "false";
 			isDebug = args[3] === "true";
 			if(utils.isValidURL(address)){


### PR DESCRIPTION
Phantom JS has a know issue where some redirects are not handled correctly, and the connection is closed before the page that the redirect pointed to finishes loading. Stylify's scraper was interpreting this failure as a 404 since that's what it used for [its fall-through case](https://github.com/DripEmail/Stylify-Me/blob/0d72ee69d79ebe77702941ab4a3c062fc0339f0b/stylify-crawler.js#L279-L282)

In our case, some dynamic behavior was redirecting loads of https://www.drip.com to go to https://www.drip.com/home, but only part of the time (possibly due to a race condition?). Even though both are valid URLs, Stylify Me was failing whenever the redirect happened.

Although the fix here significantly decreased errors in my testing, I still occasionally saw a failed query. So we might have to put in an additional layer further up the call stack to retry a few times.

## Modification

Work on Phantom has been suspended so an official fix probably won't be forthcoming, but a common workaround people have posted in various places is to manually catch the redirect attempt via the `page.onNavigationRequested` hook, and manually initiate a new page open for the target URL. See eg [this comment](https://github.com/ariya/phantomjs/issues/10389#issuecomment-103650123).

The way that the stylify scraper script was set up complicates matters a little though, since the Phantom `page` object behaves unexpectedly when multiple pages are loaded within one run. To work around this you need to close the previous page reference, then instantiate a new one with the redirect target after the close has finished. I've gotten this working by wrapping the main behavior (and `page` callback definitions) of the crawler in a function, and then recursively calling it with a short timeout whenever a redirect happens.

Additionally, I noticed that this fix led to an infinite loop when attempting to stylify google.com, because it was redirecting to a set our routes with a hash component. The JS version phantom uses does not support the [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL) (see https://github.com/ariya/phantomjs/issues/14349), so I've worked around it by scrubbing out any trailing hash components.

## How to test

This fix can be verified by executing the scraper script manually with Phantom JS. Previous to this PR, something like one in every five runs of

```
npx phantomjs stylify-crawler.js 'https://www.drip.com/' true false
```

Would fail with the error

```
ERROR(404)
```

If you run phantom with the `--debug=true` flag, or add a console log to the `page.onNavigationRequested`, you can see that it was attempting to redirect to https://www.drip.com/home.

With the changes in this PR, the same call succeeds consistently.